### PR TITLE
Bump normalize.css version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/seaneking/postcss-normalize",
   "dependencies": {
-    "normalize.css": "^4.0.0",
+    "normalize.css": "^5.0.0",
     "postcss": "^5.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
https://github.com/necolas/normalize.css/releases/tag/5.0.0
