### PR TITLE
docs: fix link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ your [browserslist].
 
 Use `@import-normalize` to determine where [normalize.css] rules should be
 included. Duplicate `@import-normalize` rules will be removed. See all the
-[Options] for more information.
+[Options](#options) for more information.
 
 ```css
 @import-normalize;


### PR DESCRIPTION
Now link refer to `https://github.com/jonathantneal/postcss-normalize#Options`
But header have different anchor `https://github.com/jonathantneal/postcss-normalize#options`