### PR TITLE
Add browserslist to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
     "rollup": "^2.6.0",
     "rollup-plugin-babel": "^4.4.0"
   },
+  "peerDependencies": {
+    "browserslist": "^4"
+  },
   "babel": {
     "plugins": [
       "@babel/plugin-syntax-import-meta"


### PR DESCRIPTION
Hello,

When installing a dependent of this package with Yarn 2, I got log output pointing out that this package has a missing peer dependency `browserslist`, because `postcss-browser-comments` has a peer dependency on it. More info [here](https://yarnpkg.com/advanced/error-codes#yn0002---missing_peer_dependency).

```
➤ YN0000: ┌ Resolution step
➤ YN0002: │ postcss-normalize@npm:9.0.0 doesn't provide browserslist@^4 requested by postcss-browser-comments@npm:3.0.0
➤ YN0000: └ Completed in 0.32s
➤ YN0000: ┌ Fetch step
➤ YN0000: └ Completed in 2.58s
➤ YN0000: ┌ Link step
➤ YN0000: └ Completed in 2.92s
➤ YN0000: Done with warnings in 6s
```

Unfortunately, this isn't just a warning; Yarn 2 Plug 'n Play throws an error when `postcss-browser-comments` attempts to require `browserslist`, even if the top-level project has `browserslist` installed.

> UnhandledPromiseRejectionWarning: Error: postcss-browser-comments tried to access browserslist (a peer dependency) but it isn't provided by its ancestors; this makes the require call ambiguous and unsound.

Adding `browserslist` to `peerDependencies` makes the intended behavior here explicit and resolves the installation warning and runtime exception. It will not be a breaking change as npm and Yarn 1 already surface a peer dependency warning from `postcss-browser-comments`.

