### PR TITLE
Feature/postcss 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   },
   "dependencies": {
     "@csstools/normalize.css": "10.1.0",
-    "postcss": "^7.0.27",
     "postcss-browser-comments": "^3.0.0",
     "sanitize.css": "11.0.0"
   },
@@ -35,15 +34,18 @@
     "@babel/plugin-syntax-import-meta": "^7.8.3",
     "@babel/preset-env": "^7.9.5",
     "babel-eslint": "^10.1.0",
+    "browserslist": "^4.16.3",
     "eslint": "^6.8.0",
+    "postcss": "^8.2.8",
     "postcss-import": "^12.0.1",
-    "postcss-tape": "^5.0.2",
+    "postcss-tape": "^6.0.1",
     "pre-commit": "^1.2.2",
     "rollup": "^2.6.0",
     "rollup-plugin-babel": "^4.4.0"
   },
   "peerDependencies": {
-    "browserslist": "^4"
+    "browserslist": "^4.16.3",
+    "postcss": "^8.2.8"
   },
   "babel": {
     "plugins": [

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
     "node": ">=10.0.0"
   },
   "dependencies": {
-    "@csstools/normalize.css": "*",
+    "@csstools/normalize.css": "10.1.0",
     "postcss": "^7.0.27",
     "postcss-browser-comments": "^3.0.0",
-    "sanitize.css": "*"
+    "sanitize.css": "11.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,24 @@
-import { assign, create } from './lib/util';
-import postcss from 'postcss';
+import { create } from './lib/util';
 import postcssBrowserComments from 'postcss-browser-comments';
 import postcssImportNormalize from './lib/postcssImportNormalize';
 import postcssNormalize from './lib/postcssNormalize';
 
-export default postcss.plugin('postcss-normalize', opts => {
+const plugin = opts => {
 	opts = create(opts);
 
-	const commentsTransformer = postcssBrowserComments(opts);
+	const commentsTransformer = postcssBrowserComments(opts).Once;
 	const normalizeTransformer = postcssNormalize(commentsTransformer, opts);
 	const postcssImportConfig = postcssImportNormalize(commentsTransformer, opts);
 
-	return assign(normalizeTransformer, { postcssImport: postcssImportConfig });
-});
+	return {
+		postcssPlugin: 'postcss-normalize',
+		Once(root) {
+			return normalizeTransformer(root)
+		},
+		postcssImport: postcssImportConfig
+	}
+}
+
+plugin.postcss = true;
+
+export default plugin;


### PR DESCRIPTION
This pull request upgrade to `postcss@8`

The test will fail because the current version of `postcss-browser-comments` still use `postcss@7`

should be merged after https://github.com/csstools/postcss-browser-comments/pull/4

### Related Issue

`postcss-browser-comments` https://github.com/csstools/postcss-browser-comments/issues/5
`create-react-app` cannot upgrade to `postcss@8` https://github.com/facebook/create-react-app/issues/9664
