### PR TITLE
Pin `sanitize.css` to `12.x` versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@csstools/normalize.css": "*",
     "postcss-browser-comments": "^4",
-    "sanitize.css": "*"
+    "sanitize.css": "^12.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.13.16",


### PR DESCRIPTION
closes #58 

This PR prevents `sanitize.css` from auto-upgrading to `13.0.0`, which removes the `page.css` file leveraged in `src/lib/cssMap.js`.

Prior to this morning, this would have installed `sanitize.css@12.0.1`, so I've chosen a careted version of that to grab any `12.x` features or fixes that may yet land there.