### PR TITLE
Removed references to sanitize.css/pages.css

### DIFF
--- a/src/lib/cssMap.js
+++ b/src/lib/cssMap.js
@@ -13,7 +13,6 @@ const normalizeCSS = resolve('@csstools/normalize.css')
 const normalizeOpinionatedCSS = resolve('@csstools/normalize.css/opinionated.css')
 const sanitizeCSS = resolve('sanitize.css')
 const sanitizeFormsCSS = resolve('sanitize.css/forms.css')
-const sanitizePageCSS = resolve('sanitize.css/page.css')
 const sanitizeTypographyCSS = resolve('sanitize.css/typography.css')
 
 // export a hashmap of css library filenames
@@ -22,7 +21,6 @@ export const parsableFilenames = create({
 	[normalizeOpinionatedCSS]: true,
 	[sanitizeCSS]: true,
 	[sanitizeFormsCSS]: true,
-	[sanitizePageCSS]: true,
 	[sanitizeTypographyCSS]: true
 })
 
@@ -33,9 +31,9 @@ export const resolvedFilenamesById = create({
 	'normalize/*': [normalizeOpinionatedCSS],
 	'sanitize': [sanitizeCSS],
 	'sanitize/forms': [sanitizeCSS, sanitizeFormsCSS],
-	'sanitize/page': [sanitizeCSS, sanitizePageCSS],
+	'sanitize/page': [sanitizeCSS],
 	'sanitize/typography': [sanitizeCSS, sanitizeTypographyCSS],
-	'sanitize/*': [sanitizeCSS, sanitizeFormsCSS, sanitizePageCSS, sanitizeTypographyCSS]
+	'sanitize/*': [sanitizeCSS, sanitizeFormsCSS, sanitizeTypographyCSS]
 })
 
 // get the resolved filename of a package/module


### PR DESCRIPTION
According to [sanitize.css changelog](https://github.com/csstools/sanitize.css/blob/main/CHANGELOG.md), the latest release removed `pages.css` file, since it was unnecessary. This PR removes references to that file from `postcss-normalize`. 

closes #58 