### PR TITLE
Support TS `moduleResolution: "node16"`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,26 +1,28 @@
 import type * as PostCSS from 'postcss'
 
-export type PluginOptions = {
-	/** Determines whether multiple, duplicate insertions are allowed */
-	allowDuplicates?: boolean
-	/** Defines an override of the project’s browserslist for this plugin. */
-	browsers?: string
-	/** Defines whether imports from this plugin will always be inserted at the beginning of a CSS file. */
-	forceImport?: boolean
-}
-
-export type Plugin = {
-	(pluginOptions?: PluginOptions): {
-		postcssPlugin: 'postcss-normalize'
-		Once(root: PostCSS.Root): void
-		postcssImport: {
-			load(filename: string, importOptions: any): {}
-			resolve(id: string, basedir: string, importOptions: any): {}
-		}
+declare namespace plugin {
+	export type PluginOptions = {
+		/** Determines whether multiple, duplicate insertions are allowed */
+		allowDuplicates?: boolean
+		/** Defines an override of the project’s browserslist for this plugin. */
+		browsers?: string
+		/** Defines whether imports from this plugin will always be inserted at the beginning of a CSS file. */
+		forceImport?: boolean
 	}
-	postcss: true
+
+	export type Plugin = {
+		(pluginOptions?: PluginOptions): {
+			postcssPlugin: 'postcss-normalize'
+			Once(root: PostCSS.Root): void
+			postcssImport: {
+				load(filename: string, importOptions: any): {}
+				resolve(id: string, basedir: string, importOptions: any): {}
+			}
+		}
+		postcss: true
+	}
 }
 
-declare const plugin: Plugin
+declare const plugin: plugin.Plugin
 
-export default plugin
+export = plugin

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "exports": {
     "require": "./index.cjs",
     "import": "./index.mjs",
-    "default": "./index.mjs"
+    "default": "./index.mjs",
+    "types": "./index.d.ts"
   },
   "files": [
     "index.d.ts",


### PR DESCRIPTION
## First issue fixed

`"moduleResolution": "node16"` in TS will cause:

```
TS7016: Could not find a declaration file for module postcss-normalize. `postcss-normalize/index.mjs` implicitly has an any type.

There are types at `postcss-normalize/index.d.ts`, but this result could not be resolved when respecting package.json exports. The postcss-normalize library may need to update its package.json or typings.
```

## Second issue fixed:

- Typescript `"moduleResolution": "node16"` requires different type info when `CJS` modules  like this one are imported from `ESM` module.
- To make default exports (`export default`) work for both CJS and ESM, we need `export = X` and not `export default X`.
- When you have multiple exports you need to create a namespace named exactly X and in there define the exports.

**refs:**
- https://github.com/microsoft/TypeScript/issues/52086
- https://stackoverflow.com/a/51238234/339872

PS/FYI: `npm run test tape` was failing even **_before_** my changes so i had to commit with `--no-verify`. 